### PR TITLE
feat: add XML namespace, fix typo, convert to autoload, update XSD

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -265,7 +265,8 @@ precision: reduced
 attrs = Atmospheric::Export::AltitudeAttrs.new.set_altitude(
   value: -2000,
   type: :geopotential,
-  unit: :meters
+  unit: :meters,
+  precision: :normal
 )
 
 attrs.to_xml
@@ -273,7 +274,7 @@ attrs.to_xml
 
 [source,xml]
 ----
-<atmosphere-attributes>
+<atmosphere-attributes xmlns="urn:iso:std:iso:2533:tech:xsd">
   <geometric-altitude unitsml="m" type="integer">-1999</geometric-altitude>
   <geometric-altitude unitsml="ft" type="integer">-6560</geometric-altitude>
   <geopotential-altitude unitsml="m" type="integer">-2000</geopotential-altitude>
@@ -281,9 +282,9 @@ attrs.to_xml
   <temperature unitsml="K" type="float">301.15</temperature>
   <temperature unitsml="degC" type="float">28.0</temperature>
   <pressure unitsml="mbar" type="float">1277.74</pressure>
-  <pressure unitsml="mm_Hg" type="float">958.382</pressure>
+  <pressure unitsml="mm_Hg" type="float">958.38</pressure>
   <density unitsml="kg*m^-3" type="float">1.47808</density>
-  <acceleration unitsml="m*s^-2" type="float">9.8128</acceleration>
+  <acceleration unitsml="m*s^-2" type="float">9.81282</acceleration>
   <ppn type="float">1.26103</ppn>
   <rhorhon type="float">1.20659</rhorhon>
   <sqrt-rhorhon type="float">1.09845</sqrt-rhorhon>
@@ -297,7 +298,7 @@ attrs.to_xml
   <mean-speed unitsml="m*s^-1" type="float">469.18</mean-speed>
   <frequency unitsml="s^-1" type="float">8535100000.0</frequency>
   <mean-free-path unitsml="m" type="float">5.4971e-08</mean-free-path>
-  <precision>reduced</precision>
+  <precision>normal</precision>
 </atmosphere-attributes>
 ----
 ====
@@ -425,13 +426,13 @@ attrs.to_xml
 
 [source,xml]
 ----
-<hypsometrical-attributes>
+<hypsometrical-attributes xmlns="urn:iso:std:iso:2533:tech:xsd">
   <pressure unitsml="mbar" type="float">5.0</pressure>
   <pressure unitsml="mm_Hg" type="float">3.7503084135</pressure>
-  <geometric-altitude unitsml="m" type="float">35979</geometric-altitude>
-  <geometric-altitude unitsml="ft" type="float">118041</geometric-altitude>
-  <geopotential-altitude unitsml="m" type="float">35776</geopotential-altitude>
-  <geopotential-altitude unitsml="ft" type="float">117377</geopotential-altitude>
+  <geometric-altitude unitsml="m" type="float">35979.0</geometric-altitude>
+  <geometric-altitude unitsml="ft" type="float">118041.0</geometric-altitude>
+  <geopotential-altitude unitsml="m" type="float">35776.5</geopotential-altitude>
+  <geopotential-altitude unitsml="ft" type="float">117377.0</geopotential-altitude>
 </hypsometrical-attributes>
 ----
 ====
@@ -1122,6 +1123,10 @@ This table is a subset of the `table_atmosphere_meters` method.
 An XSD schema for the XML serialization format is provided at
 `schema/atmospheric.xsd`.
 
+The schema uses the XML namespace `urn:iso:std:iso:2533:tech:xsd` following
+the RFC 5141 pattern for ISO technical XML schema resources. All elements
+are namespace-qualified (`elementFormDefault="qualified"`).
+
 The schema defines the following root elements:
 
 `atmospheric`:: Polymorphic root element. Two variants:
@@ -1139,7 +1144,7 @@ The schema defines the following root elements:
 [source,xml]
 ----
 <!-- Hypsometrical table variant -->
-<atmospheric>
+<atmospheric xmlns="urn:iso:std:iso:2533:tech:xsd">
   <hypsometrical-attributes>
     <pressure unitsml="mbar" type="float">1013.25</pressure>
     <pressure unitsml="mm_Hg" type="float">760.0</pressure>
@@ -1151,7 +1156,7 @@ The schema defines the following root elements:
 </atmospheric>
 
 <!-- ISO 2533:2025 table variant -->
-<atmospheric>
+<atmospheric xmlns="urn:iso:std:iso:2533:tech:xsd">
   <by-geometric-altitude>
     <atmospheric-attributes>...</atmospheric-attributes>
   </by-geometric-altitude>
@@ -1167,9 +1172,6 @@ Contains all altitude, temperature, pressure, density, and derived properties.
 
 `hypsometrical-attributes`:: Pressure-to-altitude record. Contains pressure
 and altitude values.
-
-`group-one-attrs`:: ISO 2533:1975 Group One record (temperature, pressure,
-density, acceleration). Temperature values use integer type (scaled by 1000).
 
 `attributes-group`:: Wrapper for a collection of `<atmospheric-attributes>`.
 

--- a/atmospheric.gemspec
+++ b/atmospheric.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.add_dependency "bigdecimal"
-  spec.add_dependency "lutaml-model", "~> 0.8.0"
+  spec.add_dependency "lutaml-model", ">= 0.8.0"
   spec.add_dependency "nokogiri"
 end

--- a/lib/atmospheric.rb
+++ b/lib/atmospheric.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
-require_relative "atmospheric/version"
-require_relative "atmospheric/isa"
-require_relative "atmospheric/export"
 require "lutaml/model"
 
 module Atmospheric
   class Error < StandardError; end
-  # Your code goes here...
+
+  autoload :VERSION, "atmospheric/version"
+  autoload :Isa, "atmospheric/isa"
+  autoload :Iso2533Namespace, "atmospheric/namespace"
+  autoload :UnitValueFloat, "atmospheric/unit_value_float"
+  autoload :UnitValueInteger, "atmospheric/unit_value_integer"
+  autoload :Export, "atmospheric/export"
 end

--- a/lib/atmospheric/export.rb
+++ b/lib/atmospheric/export.rb
@@ -2,10 +2,16 @@
 
 module Atmospheric
   module Export
+    autoload :Utils, "atmospheric/export/utils"
+    autoload :AltitudeTable, "atmospheric/export/altitude_table"
+    autoload :AltitudeConvertableModel, "atmospheric/export/altitude_convertable_model"
+    autoload :AltitudeAttrs, "atmospheric/export/altitude_attrs"
+    autoload :PressureAttrs, "atmospheric/export/pressure_attrs"
+    autoload :HypsometricalTable, "atmospheric/export/hypsometrical_table"
+    autoload :PrecisionValue, "atmospheric/export/precision_value"
+    autoload :Iso25331975, "atmospheric/export/iso_25331975"
+    autoload :Iso25331985, "atmospheric/export/iso_25331985"
+    autoload :Iso25331997, "atmospheric/export/iso_25331997"
+    autoload :Iso25332025, "atmospheric/export/iso_25332025"
   end
 end
-
-require_relative "export/iso_25331975"
-require_relative "export/iso_25331997"
-require_relative "export/iso_25331985"
-require_relative "export/iso_25332025"

--- a/lib/atmospheric/export/altitude_attrs.rb
+++ b/lib/atmospheric/export/altitude_attrs.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-require_relative "../unit_value_float"
-require_relative "../unit_value_integer"
-
 module Atmospheric
   module Export
     class AltitudeAttrs < Lutaml::Model::Serializable
@@ -31,7 +27,7 @@ module Atmospheric
       attribute :mean_speeds, UnitValueFloat, collection: true
       attribute :frequencies, UnitValueFloat, collection: true
       attribute :mean_free_paths, UnitValueFloat, collection: true
-      attribute :precision, :string, values: %w[reduced normal high]
+      attribute :precision, PrecisionValue
 
       key_value do
         map "geometric-altitude", to: :geometric_altitudes
@@ -65,6 +61,7 @@ module Atmospheric
 
       xml do
         element "atmosphere-attributes"
+        namespace Atmospheric::Iso2533Namespace
         map_element "geometric-altitude", to: :geometric_altitudes
         map_element "geopotential-altitude", to: :geopotential_altitudes
 

--- a/lib/atmospheric/export/altitude_convertable_model.rb
+++ b/lib/atmospheric/export/altitude_convertable_model.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "utils"
-require_relative "../unit_value_float"
-require_relative "../unit_value_integer"
-
 module Atmospheric
   module Export
     module AltitudeConvertableModel

--- a/lib/atmospheric/export/altitude_table.rb
+++ b/lib/atmospheric/export/altitude_table.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-
 module Atmospheric
   module Export
     class AltitudeTable < Lutaml::Model::Serializable

--- a/lib/atmospheric/export/hypsometrical_table.rb
+++ b/lib/atmospheric/export/hypsometrical_table.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-require_relative "pressure_attrs"
-
 module Atmospheric
   module Export
     class HypsometricalTable < Lutaml::Model::Serializable
@@ -10,6 +7,7 @@ module Atmospheric
 
       xml do
         element "atmospheric"
+        namespace Atmospheric::Iso2533Namespace
         map_element "hypsometrical-attributes", to: :rows
       end
 

--- a/lib/atmospheric/export/iso_25331975.rb
+++ b/lib/atmospheric/export/iso_25331975.rb
@@ -3,6 +3,13 @@
 module Atmospheric
   module Export
     module Iso25331975
+      autoload :GroupOne, "atmospheric/export/iso_25331975/group_one"
+      autoload :GroupTwo, "atmospheric/export/iso_25331975/group_two"
+      autoload :GroupThree, "atmospheric/export/iso_25331975/group_three"
+      autoload :GroupOneAttrs, "atmospheric/export/iso_25331975/group_one_attrs"
+      autoload :GroupTwoAttrs, "atmospheric/export/iso_25331975/group_two_attrs"
+      autoload :GroupThreeAttrs, "atmospheric/export/iso_25331975/group_three_attrs"
+
       class << self
         def table_5
           GroupOne.new.set_attrs
@@ -19,7 +26,3 @@ module Atmospheric
     end
   end
 end
-
-require_relative "iso_25331975/group_one"
-require_relative "iso_25331975/group_two"
-require_relative "iso_25331975/group_three"

--- a/lib/atmospheric/export/iso_25331975/group_one.rb
+++ b/lib/atmospheric/export/iso_25331975/group_one.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../altitude_table"
-require_relative "group_one_attrs"
-
 module Atmospheric
   module Export
     module Iso25331975

--- a/lib/atmospheric/export/iso_25331975/group_one_attrs.rb
+++ b/lib/atmospheric/export/iso_25331975/group_one_attrs.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-require_relative "../altitude_convertable_model"
-
 module Atmospheric
   module Export
     module Iso25331975

--- a/lib/atmospheric/export/iso_25331975/group_three.rb
+++ b/lib/atmospheric/export/iso_25331975/group_three.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../altitude_table"
-require_relative "group_three_attrs"
-
 module Atmospheric
   module Export
     module Iso25331975

--- a/lib/atmospheric/export/iso_25331975/group_three_attrs.rb
+++ b/lib/atmospheric/export/iso_25331975/group_three_attrs.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-
 module Atmospheric
   module Export
     module Iso25331975

--- a/lib/atmospheric/export/iso_25331975/group_two.rb
+++ b/lib/atmospheric/export/iso_25331975/group_two.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../altitude_table"
-require_relative "group_two_attrs"
-
 module Atmospheric
   module Export
     module Iso25331975

--- a/lib/atmospheric/export/iso_25331975/group_two_attrs.rb
+++ b/lib/atmospheric/export/iso_25331975/group_two_attrs.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-
 module Atmospheric
   module Export
     module Iso25331975

--- a/lib/atmospheric/export/iso_25331985.rb
+++ b/lib/atmospheric/export/iso_25331985.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "hypsometrical_table"
-require_relative "iso_25331985/pressure_attrs"
-require_relative "iso_25331985/table_five_six_attrs"
-require_relative "iso_25331975/group_one"
-
 module Atmospheric
   module Export
     module Iso25331985
+      autoload :PressureAttrs, "atmospheric/export/iso_25331985/pressure_attrs"
+      autoload :TableFiveSixAttrs, "atmospheric/export/iso_25331985/table_five_six_attrs"
+
       class TableOne < HypsometricalTable
         # TODO: when Ruby's step does not create inaccurate floating point numbers
         # This is a hack to solve a Ruby bug with floating point calcuations

--- a/lib/atmospheric/export/iso_25331985/pressure_attrs.rb
+++ b/lib/atmospheric/export/iso_25331985/pressure_attrs.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../pressure_attrs"
-
 # The purpose of this class is to trim the attributes used in the ISO 2533:1985
 # standard.
 module Atmospheric

--- a/lib/atmospheric/export/iso_25331985/table_five_six_attrs.rb
+++ b/lib/atmospheric/export/iso_25331985/table_five_six_attrs.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../iso_25331975/group_one_attrs"
-
 module Atmospheric
   module Export
     module Iso25331985

--- a/lib/atmospheric/export/iso_25331997.rb
+++ b/lib/atmospheric/export/iso_25331997.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./iso_25331975"
-
 module Atmospheric
   module Export
     module Iso25331997

--- a/lib/atmospheric/export/iso_25332025.rb
+++ b/lib/atmospheric/export/iso_25332025.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "iso_25331975"
-require_relative "iso_25332025/combined_altitude_attrs_group"
-
 module Atmospheric
   module Export
     module Iso25332025
+      autoload :AltitudeAttrsGroup, "atmospheric/export/iso_25332025/altitude_attrs_group"
+      autoload :CombinedAltitudeAttrsGroup, "atmospheric/export/iso_25332025/combined_altitude_attrs_group"
+
       class AltitudesInMeters < CombinedAltitudeAttrsGroup
         def steps
           (

--- a/lib/atmospheric/export/iso_25332025/altitude_attrs_group.rb
+++ b/lib/atmospheric/export/iso_25332025/altitude_attrs_group.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-require_relative "../altitude_attrs"
-
 # The purpose of this class is really for XML grouping.
 # It is not a table in the same sense as the other tables.
 # It is a collection of attributes grouped by altitude type.
@@ -19,6 +16,7 @@ module Atmospheric
 
         xml do
           element "attributes-group"
+          namespace Atmospheric::Iso2533Namespace
           map_element "atmospheric-attributes", to: :rows
         end
       end

--- a/lib/atmospheric/export/iso_25332025/combined_altitude_attrs_group.rb
+++ b/lib/atmospheric/export/iso_25332025/combined_altitude_attrs_group.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../altitude_table"
-require_relative "../altitude_attrs"
-require_relative "altitude_attrs_group"
-
 module Atmospheric
   module Export
     module Iso25332025
@@ -18,6 +14,7 @@ module Atmospheric
 
         xml do
           element "atmospheric"
+          namespace Atmospheric::Iso2533Namespace
           map_element "by-geometric-altitude", to: :by_geometric_altitude
           map_element "by-geopotential-altitude", to: :by_geopotential_altitude
         end

--- a/lib/atmospheric/export/precision_value.rb
+++ b/lib/atmospheric/export/precision_value.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Atmospheric
+  class PrecisionValue < Lutaml::Model::Type::String
+    xml do
+      namespace Atmospheric::Iso2533Namespace
+    end
+  end
+end

--- a/lib/atmospheric/export/pressure_attrs.rb
+++ b/lib/atmospheric/export/pressure_attrs.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-require_relative "utils"
-require_relative "../unit_value_float"
-require_relative "../unit_value_integer"
-
 module Atmospheric
   module Export
     class PressureAttrs < Lutaml::Model::Serializable
@@ -21,6 +16,7 @@ module Atmospheric
 
       xml do
         element "hypsometrical-attributes"
+        namespace Atmospheric::Iso2533Namespace
         map_element "pressure", to: :pressures
         map_element "geometric-altitude", to: :geometric_altitudes
         map_element "geopotential-altitude", to: :geopotential_altitudes

--- a/lib/atmospheric/namespace.rb
+++ b/lib/atmospheric/namespace.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Atmospheric
+  class Iso2533Namespace < Lutaml::Xml::W3c::XmlNamespace
+    prefix_default "iso2533"
+    uri "urn:iso:std:iso:2533:tech:xsd"
+  end
+end

--- a/lib/atmospheric/unit_value_float.rb
+++ b/lib/atmospheric/unit_value_float.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-
 module Atmospheric
   class UnitValueFloat < Lutaml::Model::Serializable
     attribute :value, :float
@@ -15,7 +13,8 @@ module Atmospheric
     end
 
     xml do
-      element "unitl-value-float"
+      element "unit-value-float"
+      namespace Atmospheric::Iso2533Namespace
       map_content to: :value
       map_attribute :unitsml, to: :unitsml
       map_attribute :type, to: :type, render_default: true

--- a/lib/atmospheric/unit_value_integer.rb
+++ b/lib/atmospheric/unit_value_integer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "lutaml/model"
-
 module Atmospheric
   class UnitValueInteger < Lutaml::Model::Serializable
     attribute :value, :integer
@@ -16,6 +14,7 @@ module Atmospheric
 
     xml do
       element "unit-value-integer"
+      namespace Atmospheric::Iso2533Namespace
       map_content to: :value
       map_attribute :unitsml, to: :unitsml
       map_attribute :type, to: :type, render_default: true

--- a/schema/atmospheric.xsd
+++ b/schema/atmospheric.xsd
@@ -1,39 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:iso:std:iso:2533:tech:xsd"
+           xmlns:iso="urn:iso:std:iso:2533:tech:xsd"
+           elementFormDefault="qualified">
 
-  <!--
-    XML Schema for the Atmospheric gem (ISO 2533 Standard Atmosphere).
-    Defines the XML serialization format for atmospheric property tables.
-  -->
+  <xs:annotation>
+    <xs:documentation>
+      XML Schema for the Atmospheric gem (ISO 2533:2026 Standard Atmosphere).
+      Defines the XML serialization format for atmospheric property tables.
+
+      Namespace: urn:iso:std:iso:2533:tech:xsd
+      All elements are qualified in this namespace.
+
+      Unit conventions:
+        - Altitudes: m (metres), ft (feet)
+        - Temperature: K (kelvin), degC (degrees Celsius)
+        - Pressure: mbar (millibars), mm_Hg (millimetres of mercury)
+        - Density: kg*m^-3 (kilograms per cubic metre)
+        - Speed: m*s^-1 (metres per second)
+        - Viscosity: Pa*s (pascal-seconds), m^2*s^-1 (square metres per second)
+        - Thermal conductivity: W*m^-1*K^-1 (watts per metre-kelvin)
+        - Length: m (metres)
+        - Weight: N*m^-3 (newtons per cubic metre)
+        - Number density: m^-3 (per cubic metre)
+        - Frequency: s^-1 (per second)
+    </xs:documentation>
+  </xs:annotation>
 
   <!-- ============================================================ -->
   <!-- Top-level root elements                                       -->
   <!-- ============================================================ -->
 
-  <!-- Main table container (used by HypsometricalTable and ISO 2533:2025 tables) -->
-  <xs:element name="atmospheric" type="atmospheric-type"/>
+  <xs:annotation>
+    <xs:documentation>
+      Root elements:
+        - atmospheric: polymorphic container supporting two variants:
+            1. Combined altitude attributes table (by-geometric / by-geopotential)
+            2. Hypsometrical table (pressure to altitude)
+        - atmosphere-attributes: single altitude attributes record
+        - hypsometrical-attributes: single pressure-to-altitude record
+        - attributes-group: standalone wrapper for multiple atmosphere-attributes
+        - unit-value-float: standalone float value with units
+        - unit-value-integer: standalone integer value with units
+    </xs:documentation>
+  </xs:annotation>
 
-  <!-- Full atmospheric attributes record (ISO 2533:2025) -->
-  <xs:element name="atmosphere-attributes" type="atmosphere-attributes-type"/>
+  <xs:element name="atmospheric" type="iso:atmospheric-type"/>
 
-  <!-- Hypsometrical attributes record (pressure → altitude) -->
-  <xs:element name="hypsometrical-attributes" type="hypsometrical-attributes-type"/>
+  <xs:element name="atmosphere-attributes" type="iso:atmosphere-attributes-type">
+    <xs:annotation>
+      <xs:documentation>
+        Full atmospheric attributes record for a single altitude. Contains all
+        physical properties defined in ISO 2533:2026: altitudes, temperature,
+        pressure, density, gravity acceleration, and derived quantities.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
 
-  <!-- ISO 2533:1975 Group One attributes -->
-  <xs:element name="group-one-attrs" type="group-one-attrs-type"/>
+  <xs:element name="hypsometrical-attributes" type="iso:hypsometrical-attributes-type">
+    <xs:annotation>
+      <xs:documentation>
+        Hypsometrical attributes record mapping a given pressure to geometric
+        and geopotential altitudes.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
 
-  <!-- Attributes group wrapper (ISO 2533:2025 standalone) -->
-  <xs:element name="attributes-group" type="attributes-group-type"/>
+  <xs:element name="attributes-group" type="iso:attributes-group-type">
+    <xs:annotation>
+      <xs:documentation>
+        Standalone wrapper for a collection of atmosphere-attributes records.
+        Used when grouping multiple altitude records without the combined
+        by-geometric / by-geopotential structure.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
 
-  <!-- Standalone unit value elements -->
-  <xs:element name="unitl-value-float" type="unit-value-float-type"/>
-  <xs:element name="unit-value-integer" type="unit-value-integer-type"/>
+  <xs:element name="unit-value-float" type="iso:unit-value-float-type"/>
+  <xs:element name="unit-value-integer" type="iso:unit-value-integer-type"/>
 
   <!-- ============================================================ -->
   <!-- Simple types                                                  -->
   <!-- ============================================================ -->
 
   <xs:simpleType name="precision-type">
+    <xs:annotation>
+      <xs:documentation>
+        Precision mode used for atmospheric calculations.
+        - reduced: fewer significant digits, faster computation
+        - normal: standard precision for general use
+        - high: maximum precision for scientific applications
+      </xs:documentation>
+    </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="reduced"/>
       <xs:enumeration value="normal"/>
@@ -46,6 +104,14 @@
   <!-- ============================================================ -->
 
   <xs:complexType name="unit-value-float-type">
+    <xs:annotation>
+      <xs:documentation>
+        A floating-point value with optional units (UnitsML notation) and a
+        required type indicator. The unitsml attribute specifies measurement
+        units (e.g., "m", "kg*m^-3", "mbar"). The type attribute is always
+        "float" for this type.
+      </xs:documentation>
+    </xs:annotation>
     <xs:simpleContent>
       <xs:extension base="xs:double">
         <xs:attribute name="unitsml" type="xs:string" use="optional"/>
@@ -55,6 +121,13 @@
   </xs:complexType>
 
   <xs:complexType name="unit-value-integer-type">
+    <xs:annotation>
+      <xs:documentation>
+        An integer value with optional units (UnitsML notation) and a required
+        type indicator. The unitsml attribute specifies measurement units
+        (e.g., "m", "ft"). The type attribute is always "integer" for this type.
+      </xs:documentation>
+    </xs:annotation>
     <xs:simpleContent>
       <xs:extension base="xs:integer">
         <xs:attribute name="unitsml" type="xs:string" use="optional"/>
@@ -68,139 +141,259 @@
   <!--                                                               -->
   <!-- Two variants:                                                 -->
   <!--   1. HypsometricalTable: sequence of hypsometrical-attributes -->
-  <!--   2. ISO 2533:2025 table: by-geometric / by-geopotential     -->
+  <!--   2. ISO 2533:2026 table: by-geometric / by-geopotential     -->
   <!-- ============================================================ -->
 
   <xs:complexType name="atmospheric-type">
+    <xs:annotation>
+      <xs:documentation>
+        Polymorphic root container. Supports two content models:
+        1. Combined altitude attributes table with separate sections for
+           geometric and geopotential altitude lookups.
+        2. Hypsometrical table mapping pressures to altitudes.
+      </xs:documentation>
+    </xs:annotation>
     <xs:choice>
-      <!-- Variant 1: Hypsometrical table (pressure → altitude) -->
+      <!-- Variant 1: Combined altitude attributes table -->
+      <xs:sequence>
+        <xs:element name="by-geometric-altitude" type="iso:by-altitude-type">
+          <xs:annotation>
+            <xs:documentation>
+              Section containing atmospheric attributes indexed by geometric altitude.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="by-geopotential-altitude" type="iso:by-altitude-type">
+          <xs:annotation>
+            <xs:documentation>
+              Section containing atmospheric attributes indexed by geopotential altitude.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <!-- Variant 2: Hypsometrical table (pressure to altitude) -->
       <xs:sequence>
         <xs:element name="hypsometrical-attributes"
-                    type="hypsometrical-attributes-type"
+                    type="iso:hypsometrical-attributes-type"
                     maxOccurs="unbounded"/>
-      </xs:sequence>
-      <!-- Variant 2: ISO 2533:2025 altitude attributes table -->
-      <xs:sequence>
-        <xs:element name="by-geometric-altitude" type="by-altitude-type"/>
-        <xs:element name="by-geopotential-altitude" type="by-altitude-type"/>
       </xs:sequence>
     </xs:choice>
   </xs:complexType>
 
-  <!-- By-altitude section wrapper (ISO 2533:2025) -->
+  <!-- By-altitude section wrapper (ISO 2533:2026) -->
   <xs:complexType name="by-altitude-type">
+    <xs:annotation>
+      <xs:documentation>
+        Wrapper for a collection of atmospheric-attributes records,
+        all indexed by the same altitude type (geometric or geopotential).
+      </xs:documentation>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="atmospheric-attributes"
-                  type="atmosphere-attributes-type"
+                  type="iso:atmosphere-attributes-type"
                   maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 
   <!-- ============================================================ -->
-  <!-- Atmosphere attributes type (ISO 2533:2025 full record)        -->
+  <!-- Atmosphere attributes type (ISO 2533:2026 full record)        -->
   <!-- ============================================================ -->
 
   <xs:complexType name="atmosphere-attributes-type">
+    <xs:annotation>
+      <xs:documentation>
+        Complete atmospheric attributes record for a single altitude. Contains
+        primary properties (altitude, temperature, pressure, density, gravity),
+        secondary ratios and transport properties, and derived molecular
+        properties. Each property may appear multiple times with different
+        units. The precision element records the calculation precision mode used.
+      </xs:documentation>
+    </xs:annotation>
     <xs:sequence>
       <!-- Altitudes -->
       <xs:element name="geometric-altitude"
-                  type="unit-value-integer-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-integer-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Geometric altitude above sea level (e.g., m, ft).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="geopotential-altitude"
-                  type="unit-value-integer-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-integer-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Geopotential altitude (e.g., m, ft).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
 
       <!-- Group One: primary atmospheric properties -->
       <xs:element name="temperature"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Atmospheric temperature (K or degC).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="pressure"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Atmospheric pressure (mbar or mm_Hg).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="density"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Air density (kg*m^-3).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="acceleration"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Acceleration due to gravity (m*s^-2).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
 
       <!-- Group Two: secondary atmospheric properties -->
       <xs:element name="ppn"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Pressure ratio (dimensionless).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="rhorhon"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Density ratio rho/rho_0 (dimensionless).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="sqrt-rhorhon"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Square root of density ratio (dimensionless).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="speed-of-sound"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Speed of sound (m*s^-1).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="dynamic-viscosity"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Dynamic viscosity (Pa*s).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="kinematic-viscosity"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Kinematic viscosity (m^2*s^-1).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="thermal-conductivity"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Thermal conductivity (W*m^-1*K^-1).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
 
       <!-- Group Three: derived atmospheric properties -->
       <xs:element name="pressure-scale-height"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Pressure scale height (m).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="specific-weight"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Specific weight of air (N*m^-3).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="air-number-density"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Number density of air molecules (m^-3).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="mean-speed"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Mean speed of air molecules (m*s^-1).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="frequency"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Collision frequency of air molecules (s^-1).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="mean-free-path"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Mean free path of air molecules (m).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
 
       <!-- Precision mode -->
-      <xs:element name="precision" type="precision-type"/>
+      <xs:element name="precision" type="iso:precision-type">
+        <xs:annotation>
+          <xs:documentation>
+            Precision mode used for atmospheric calculations in this record.
+            One of: reduced, normal, high.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <!-- ============================================================ -->
-  <!-- Hypsometrical attributes type (pressure → altitude)           -->
+  <!-- Hypsometrical attributes type (pressure to altitude)          -->
   <!-- ============================================================ -->
 
   <xs:complexType name="hypsometrical-attributes-type">
+    <xs:annotation>
+      <xs:documentation>
+        Record mapping a given atmospheric pressure to geometric and
+        geopotential altitudes. Used for hypsometrical (pressure-based)
+        altitude lookups.
+      </xs:documentation>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="pressure"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Atmospheric pressure (mbar or mm_Hg).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="geometric-altitude"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Geometric altitude above sea level (m or ft).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="geopotential-altitude"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
+                  type="iso:unit-value-float-type" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Geopotential altitude (m or ft).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 
   <!-- ============================================================ -->
-  <!-- Attributes group type (ISO 2533:2025 standalone wrapper)      -->
+  <!-- Attributes group type (ISO 2533:2026 standalone wrapper)      -->
   <!-- ============================================================ -->
 
   <xs:complexType name="attributes-group-type">
+    <xs:annotation>
+      <xs:documentation>
+        Standalone wrapper for a collection of atmospheric-attributes records.
+        Provides a flat list alternative to the combined by-geometric /
+        by-geopotential structure.
+      </xs:documentation>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="atmospheric-attributes"
-                  type="atmosphere-attributes-type"
+                  type="iso:atmosphere-attributes-type"
                   maxOccurs="unbounded"/>
-    </xs:sequence>
-  </xs:complexType>
-
-  <!-- ============================================================ -->
-  <!-- Group One attrs type (ISO 2533:1975)                          -->
-  <!--                                                               -->
-  <!-- Temperatures use UnitValueInteger (scaled by 1000)            -->
-  <!-- Other values use UnitValueFloat                               -->
-  <!-- ============================================================ -->
-
-  <xs:complexType name="group-one-attrs-type">
-    <xs:sequence>
-      <xs:element name="geometric-altitude"
-                  type="unit-value-integer-type" maxOccurs="unbounded"/>
-      <xs:element name="geopotential-altitude"
-                  type="unit-value-integer-type" maxOccurs="unbounded"/>
-      <xs:element name="temperature"
-                  type="unit-value-integer-type" maxOccurs="unbounded"/>
-      <xs:element name="pressure"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
-      <xs:element name="density"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
-      <xs:element name="acceleration"
-                  type="unit-value-float-type" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 


### PR DESCRIPTION
## Summary

- Add XML namespace `urn:iso:std:iso:2533:tech:xsd` (following RFC 5141 pattern) to all XML-serializable models via new `Iso2533Namespace` class
- Fix `unitl-value-float` typo in element name (was generating invalid XML)
- Convert all `require_relative` calls to Ruby `autoload` for lazy loading
- Add `PrecisionValue` type class for proper XML namespace on the `<precision>` element
- Rewrite `atmospheric.xsd` with namespace, `xs:annotation` docs, removed 1975-only types
- Update gemspec dependency to `lutaml-model >= 0.8.0`

## Changes

### New files
- `lib/atmospheric/namespace.rb` — `Iso2533Namespace < Lutaml::Xml::W3c::XmlNamespace` with `uri "urn:iso:std:iso:2533:tech:xsd"`
- `lib/atmospheric/export/precision_value.rb` — `PrecisionValue < Lutaml::Model::Type::String` with namespace (needed for YAML round-trip compatibility)

### Fixed
- `lib/atmospheric/unit_value_float.rb` — `element "unitl-value-float"` → `element "unit-value-float"`
- `atmospheric.gemspec` — `lutaml-model ~> 0.8.0` → `>= 0.8.0`

### Refactored
- `lib/atmospheric.rb` and `lib/atmospheric/export.rb` — converted from `require_relative` to `autoload`
- All sub-module files (`iso_25331975.rb`, `iso_25332025.rb`, etc.) — converted to autoload
- All model class files — removed `require_relative` statements

### Schema
- `schema/atmospheric.xsd` — complete rewrite with `targetNamespace="urn:iso:std:iso:2533:tech:xsd"`, `elementFormDefault="qualified"`, `xs:annotation` documentation, removed 1975-only types

## Test plan
- [x] All 20,339 existing tests pass (`bundle exec rspec`)
- [x] XML output includes correct namespace on all elements
- [x] YAML round-trip serialization works for all model types
- [x] `PrecisionValue` correctly serializes in both YAML (plain string) and XML (with namespace)